### PR TITLE
Added standalone article page

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -5,3 +5,33 @@ from flask import render_template
 @app.route('/index')
 def index():
     return render_template("index.html", title="Testpage")
+
+@app.route('/article/<int:article_id>')
+def article(article_id):
+    #dummy album data for testing, get this from a database in future
+    if (article_id == 0):
+        album = {
+        "id": 0,
+        "title": "Placeholder",
+        "album_art": "https://cdn.discordapp.com/attachments/1229708541569269811/1229708580932948048/artist_-_placeholder.png?ex=6630aa5c&is=661e355c&hm=7d4c8fa2dc2be498ce4bbe1b83754477734627d85f97d6684e162901afb70431&",
+        "artist": "Artist",
+        "year": "1970",
+        "type": "EP",
+        "star_rating": 7,
+        "review_no": 5,
+        "rating_no": 20,
+        }
+    if (article_id == 1):
+        album = {
+        "id": 1,
+        "title": "Placeholder 2",
+        "album_art": "https://cdn.discordapp.com/attachments/1229708541569269811/1229726976277872650/artist_-_placeholder_2.png?ex=6630bb7e&is=661e467e&hm=ff19805dd91cbf428109f67915d36e58151aa14c548523d22ef7619643ac35d0&",
+        "artist": "Artist",
+        "year": "1971",
+        "type": "EP",
+        "star_rating": 1,
+        "review_no": 3,
+        "rating_no": 17,
+        }
+    return render_template("article_full.html", title = "" + album["artist"] + " - " + album["title"], album=album)
+

--- a/app/templates/article_full.html
+++ b/app/templates/article_full.html
@@ -1,0 +1,64 @@
+{% extends "base.html" %}
+{% block content %}
+<body>
+    <!-- Bootstrap -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@3.3.7/dist/css/bootstrap.min.css">
+    <!-- jQuery -->
+    <script src="https://code.jquery.com/jquery-3.7.1.js"></script>
+
+    <div class="container" style="border: black solid 3px;">
+        <div class="row">
+            <!-- Album Image -->
+            <div class="col-xs-4 col-sm-4 col-md-4 col-lg-4">
+                <img src="{{ album.album_art }}" style="width:300px; margin:10px; border:black solid 3px;">
+            </div>
+
+            <!-- Album Info -->
+            <div class = "col-xs-7 col-sm-7 col-md-7 col-lg-7">
+
+                <div class="row">
+                    <h1 style="font-size: 40pt;">{{ album.title }}</h1>
+                </div>
+
+                <div class="row">
+                    <h3>{{ album.artist }} / {{ album.year }} / {{ album.type }}</h3>
+                </div>
+
+                <div class="row">
+                    <h3 id="star_rating"></h3>
+                </div>
+
+                <div class="row">
+                    <h3> {{ album.review_no }} reviews, {{ album.rating_no }} ratings</h3>
+                </div>
+            </div>
+
+            <!-- Follow Button -->
+            <div class = "col-xs-1 col-sm-1 col-md-1 col-lg-1">
+                <p>[button]</p>
+            </div>
+        </div>
+    </div>
+
+    <div class="container">
+        <p>put reviews here</p>
+    </div>
+
+    <!-- Star Rating Script-->
+    <script>
+        let rating = "{{ album.star_rating }}" - 0;
+        for (i = 0; i < 5; i++) { //loop 5 times
+            console.log(rating)
+            if ((rating - 2) > 0) { 
+                $("#star_rating").append("STAR "); //add full star
+                rating -= 2
+            } else if ((rating - 1) == 0) { 
+                $("#star_rating").append("HALF "); //add half star
+                rating -= 1
+            } else { 
+                $("#star_rating").append("NONE "); //add empty star
+            }
+        }
+    </script>
+</body>
+{% endblock %}


### PR DESCRIPTION
Created the standalone version of the articles page.
There will need to be a separate template in the future for the stubs of articles shown on the home page (I think, there could be a way to use the same template for both but idk yet).
Currently just pulls data from 2 sets of dummy data in routes.py and displays them on /articles/0 and /articles/1.
I also wrote a little script to convert from 0-10 ratings to stars, just displaying as text until we settle on what we're going to do.